### PR TITLE
extended position command to support start pos, fen and moves

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -149,8 +149,17 @@ Engine.prototype.uciNewGameCommand = function () {
 //@method positionCommand
 //
 //@param  {String}  fen  The fen string of the position
-Engine.prototype.positionCommand = function (fen) {
-    this.engineProcess.stdin.write('position fen ' + fen + endOfLine);
+Engine.prototype.positionCommand = function (fen,moves) {
+    this.engineProcess.stdin.write('position ');
+    if (fen !== '') {
+      this.engineProcess.stdin.write('fen ' + fen);
+    } else {
+      this.engineProcess.stdin.write('startpos');
+    }
+    if (moves !== '') {
+      this.engineProcess.stdin.write(' moves ' + moves);
+    }
+    this.engineProcess.stdin.write(endOfLine);
     return this.isReadyCommand();
 };
 


### PR DESCRIPTION
I have added support for the other aspects of the UCI position command (namely made fen optional and added an optional moves string). I do not think this is ready to be just merged in since I am not familiar with the commenting style or understand your testing regime. My JS skills are somewhat limited still. But you may find it useful and want to improve it sufficiently to actually add it.

Thanks for providing such a great little wrapper! Made a difference for me.
