### PR TITLE
bugfix / regexp space trouble

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -203,6 +203,7 @@ Engine.prototype.timeLimitedGoCommand = function (infoHandler,
                 self.engineProcess.stdout.removeListener('data', engineStdoutListener);
                 var moveRegex = /bestmove (\w+)(.*)?/g;
                 var match = moveRegex.exec(lines[i]);
+								if (!match && lines[i].length==13) match = moveRegex.exec(lines[i]+' ');
                 if (match) {
                     deferred.resolve(utilities.convertToMoveObject(match[1]));
                 } else {
@@ -272,6 +273,7 @@ Engine.prototype.stopCommand = function () {
                 self.engineProcess.stdout.removeListener('data', engineStdoutListener);
                 var moveRegex = /bestmove (\w+)(.*)?/g;
                 var match = moveRegex.exec(lines[i]);
+								if (!match && lines[i].length==13) match = moveRegex.exec(lines[i]+' ');
                 if (match) {
                     deferred.resolve(utilities.convertToMoveObject(match[1]));
                 } else {


### PR DESCRIPTION
Fix of the bug that I've faced when used it with Stockfish 6 SSE Engine,
which spitted at me with errors, when everything were OK, because when
it is a last move before gameover, the Engine returns that string
without trailing space.
